### PR TITLE
Ensure saturation/lightness between 0 and 1

### DIFF
--- a/lua/colors.lua
+++ b/lua/colors.lua
@@ -200,7 +200,10 @@ end
 -- @return               a new instance of Color
 -----------------------------------------------------------------------------
 function Color:desaturate_by(r)
-   return new(self.H, self.S*r, self.L)
+   local s = self.S * r
+   if s < 0 then s = 0 end
+   if s > 1 then s = 1 end
+   return new(self.H, s, self.L)
 end	      
 
 -----------------------------------------------------------------------------
@@ -220,7 +223,10 @@ end
 -- @return               a new instance of Color
 -----------------------------------------------------------------------------
 function Color:lighten_by(r)
-   return new(self.H, self.S, self.L*r)
+   local l = self.L * r
+   if l < 0 then l = 0 end
+   if l > 1 then l = 1 end
+   return new(self.H, self.S, l)
 end
 
 -----------------------------------------------------------------------------


### PR DESCRIPTION
Original pull request description:

The current `Color:desaturate_by()` function allows you to multiply the saturation value of the color to greater than 1, and less than 0. The result is obviously invalid colors being returned in such cases. See:

```lua
local color = Color.new("#ff0000")
local saturated_color = color:desaturate_by(1.1)
print(tostring(saturated_color)) -- result: #10cfffffffffffffff3fffffffffffffff3
```

The same goes for `Color:lighten_by()`:

```lua
local color = Color.new("#ffffff")
local lighter_color = color:lighten_by(1.1)
print(tostring(lighter_color)) -- result: #119119119
```

I've added a couple of checks to each function so now:

```lua
print(tostring(saturated_color)) -- result: #ff0000
print(tostring(lighter_color)) -- result: #ffffff
```